### PR TITLE
Feat/slide graph

### DIFF
--- a/velo-b/public/data/dummy.json
+++ b/velo-b/public/data/dummy.json
@@ -1,3 +1,0 @@
-{
-  "message": "Some data from JSON :-)"
-}

--- a/velo-b/public/data/slide-graph.json
+++ b/velo-b/public/data/slide-graph.json
@@ -28,7 +28,8 @@
       "ok": "question-transports-velo",
       "info": "info-choix-transports",
       "gauche": "choix-transport-bicloo",
-      "droite": "choix-transport-voiture"
+      "droite": "choix-transport-voiture",
+      "retour": "page-carte"
     }
   },
   "info-choix-transports": {
@@ -41,7 +42,8 @@
       "ok": "question-velo-autres-transports",
       "info": "info-choix-velo",
       "gauche": "choix-transport-voiture",
-      "droite": "choix-transport-bicloo"
+      "droite": "choix-transport-bicloo",
+      "retour": "page-carte"
     }
   },
   "info-choix-velo": {
@@ -54,7 +56,8 @@
       "ok": "question-bicloo-autres-transports",
       "info": "info-choix-bicloo",
       "gauche": "choix-transport-velo",
-      "droite": "choix-transport-transports"
+      "droite": "choix-transport-transports",
+      "retour": "page-carte"
     }
   },
   "info-choix-bicloo": {
@@ -67,7 +70,8 @@
       "ok": "question-voiture-velo",
       "info": "info-choix-voiture",
       "gauche": "choix-transport-transports",
-      "droite": "choix-transport-velo"
+      "droite": "choix-transport-velo",
+      "retour": "page-carte"
     }
   },
   "info-choix-voiture": {

--- a/velo-b/public/data/slide-graph.json
+++ b/velo-b/public/data/slide-graph.json
@@ -1,0 +1,118 @@
+{
+  "page-accueil": {
+    "next": {
+      "ok": "page-carte"
+    }
+  },
+  "page-carte": {
+    "next": {
+      "nord": "info-choix-carte",
+      "sud": "info-choix-carte",
+      "est": "info-choix-carte",
+      "ouest": "info-choix-carte"
+    }
+  },
+  "info-choix-carte": {
+    "next": {
+      "ok": "choix-transport-transports"
+    }
+  },
+  "choix-transport-transports": {
+    "next": {
+      "ok": "question-transports-velo",
+      "info": "info-choix-transports"
+    }
+  },
+  "info-choix-transports": {
+    "next": {
+      "ok": "choix-transport-transports"
+    }
+  },
+  "choix-transport-velo": {
+    "next": {
+      "ok": "question-velo-autres-transports",
+      "info": "info-choix-velo"
+    }
+  },
+  "info-choix-velo": {
+    "next": {
+      "ok": "choix-transport-velo"
+    }
+  },
+  "choix-transport-bicloo": {
+    "next": {
+      "ok": "question-bicloo-autres-transports",
+      "info": "info-choix-bicloo"
+    }
+  },
+  "info-choix-bicloo": {
+    "next": {
+      "ok": "choix-transport-bicloo"
+    }
+  },
+  "choix-transport-voiture": {
+    "next": {
+      "ok": "question-voiture-velo",
+      "info": "info-choix-voiture"
+    }
+  },
+  "info-choix-voiture": {
+    "next": {
+      "ok": "choix-transport-voiture"
+    }
+  },
+  "question-transports-velo": {
+    "next": {
+      "oui": "choix-transport-velo",
+      "non": "question-transports-bicloo"
+    }
+  },
+  "question-transports-bicloo": {
+    "next": {
+      "oui": "choix-transport-bicloo",
+      "non": "page-finale"
+    }
+  },
+  "question-velo-autres-transports": {
+    "next": {
+      "oui": "choix-transport-transports",
+      "non": "question-garer-velo"
+    }
+  },
+  "question-bicloo-autres-transports": {
+    "next": {
+      "oui": "choix-transport-transports",
+      "non": "question-garer-velo"
+    }
+  },
+  "question-garer-velo": {
+    "next": {
+      "consigne": "page-finale",
+      "sauvage": "page-finale"
+    }
+  },
+  "question-voiture-velo": {
+    "next": {
+      "oui": "choix-transport-velo",
+      "non": "question-voiture-bicloo"
+    }
+  },
+  "question-voiture-bicloo": {
+    "next": {
+      "oui": "choix-transport-bicloo",
+      "non": "question-voiture-transport"
+    }
+  },
+  "question-voiture-transport": {
+    "next": {
+      "oui": "choix-transport-transports",
+      "non": "question-voiture-parking"
+    }
+  },
+  "question-voiture-parking": {
+    "next": {
+      "gratuit": "page-finale",
+      "payant": "page-finale"
+    }
+  }
+}

--- a/velo-b/public/data/slide-graph.json
+++ b/velo-b/public/data/slide-graph.json
@@ -6,6 +6,12 @@
   },
   "page-carte": {
     "next": {
+      "nord": "choix-transport-velo",
+      "sud": "choix-transport-velo",
+      "est": "choix-transport-velo",
+      "ouest": "choix-transport-velo"
+    },
+    "realNext": {
       "nord": "info-choix-carte",
       "sud": "info-choix-carte",
       "est": "info-choix-carte",

--- a/velo-b/public/data/slide-graph.json
+++ b/velo-b/public/data/slide-graph.json
@@ -1,4 +1,9 @@
 {
+  "splash-screen": {
+    "next": {
+      "timeout": "page-accueil"
+    }
+  },
   "page-accueil": {
     "next": {
       "ok": "page-carte"

--- a/velo-b/public/data/slide-graph.json
+++ b/velo-b/public/data/slide-graph.json
@@ -26,7 +26,9 @@
   "choix-transport-transports": {
     "next": {
       "ok": "question-transports-velo",
-      "info": "info-choix-transports"
+      "info": "info-choix-transports",
+      "gauche": "choix-transport-bicloo",
+      "droite": "choix-transport-voiture"
     }
   },
   "info-choix-transports": {
@@ -37,7 +39,9 @@
   "choix-transport-velo": {
     "next": {
       "ok": "question-velo-autres-transports",
-      "info": "info-choix-velo"
+      "info": "info-choix-velo",
+      "gauche": "choix-transport-voiture",
+      "droite": "choix-transport-bicloo"
     }
   },
   "info-choix-velo": {
@@ -48,7 +52,9 @@
   "choix-transport-bicloo": {
     "next": {
       "ok": "question-bicloo-autres-transports",
-      "info": "info-choix-bicloo"
+      "info": "info-choix-bicloo",
+      "gauche": "choix-transport-velo",
+      "droite": "choix-transport-transports"
     }
   },
   "info-choix-bicloo": {
@@ -59,7 +65,9 @@
   "choix-transport-voiture": {
     "next": {
       "ok": "question-voiture-velo",
-      "info": "info-choix-voiture"
+      "info": "info-choix-voiture",
+      "gauche": "choix-transport-transports",
+      "droite": "choix-transport-velo"
     }
   },
   "info-choix-voiture": {

--- a/velo-b/public/index.html
+++ b/velo-b/public/index.html
@@ -73,7 +73,7 @@
 
             <!--choix transport 1 : voiture -->
 
-            <section data-slidr="choix-transport-1" hidden>
+            <section data-slidr="choix-transport-voiture" hidden>
                 <img class="background-index bottom-0 left-0 w-screen place-self-start absolute"
                     src="assets/backgrounds/backgroundVoiture.svg"></img>
                 <header>
@@ -107,7 +107,7 @@
 
             <!--choix transport 2 : velo -->
 
-            <section data-slidr="choix-transport-2" hidden>
+            <section data-slidr="choix-transport-velo" hidden>
                 <img class="background-index bottom-0 left-0 w-screen place-self-start absolute"
                     src="assets/backgrounds/backgroundVelo.svg"></img>
                 <header>
@@ -141,7 +141,7 @@
 
             <!--choix transport 3 : bicloo -->
 
-            <section data-slidr="choix-transport-3" hidden>
+            <section data-slidr="choix-transport-bicloo" hidden>
                 <img class="background-index bottom-0 left-0 w-screen place-self-start absolute"
                     src="assets/backgrounds/backgroundBicloo.svg"></img>
                 <header>
@@ -174,7 +174,7 @@
 
             <!--choix transport 4 : transport en commun -->
 
-            <section data-slidr="choix-transport-4" hidden>
+            <section data-slidr="choix-transport-transports" hidden>
                 <img class="background-index bottom-0 left-0 w-screen place-self-start absolute"
                     src="assets/backgrounds/backgroundTransport.svg"></img>
                 <header>
@@ -248,7 +248,7 @@
 
             <!--Infos liés a selection véhicule  -->
 
-            <section data-slidr="infos-selection-voiture"
+            <section data-slidr="question-voiture-velo"
                      style="background: url(assets/cheminVoiture/fondvoiture.svg) no-repeat center" hidden>
                 <img src="assets/cheminVoiture/bulle-info-lg.svg" class="absolute inset-0 w-1/2 mt-5 mx-auto"
                     id="ic-bulle-info-voit" alt="Bulle info"></img>
@@ -261,7 +261,7 @@
                 </div>
             </section>
 
-            <section data-slidr="infos-selection-velo"
+            <section data-slidr="question-velo-autres-transports"
                      style="background: url(assets/cheminVelo/fondvelo.svg) no-repeat center" hidden>
                 <img src="assets/cheminVelo/bulle-info-lg.svg" class="absolute inset-0 w-1/2 mt-5 mx-auto"
                      id="ic-bulle-info-velo" alt="Bulle info"></img>
@@ -274,7 +274,7 @@
                 </div>
             </section>
 
-            <section data-slidr="infos-selection-bicloo"
+            <section data-slidr="question-bicloo-autres-transports"
                      style="background: url(assets/cheminBicloo/fondbicloo.svg) no-repeat center" hidden>
                 <img src="assets/cheminBicloo/bulle-info-lg.svg" class="absolute inset-0 w-1/2 mt-5 mx-auto"
                      id="ic-bulle-info-bicloo" alt="Bulle info"></img>
@@ -287,7 +287,7 @@
                 </div>
             </section>
 
-            <section data-slidr="infos-selection-transport"
+            <section data-slidr="question-transports-velo"
                      style="background: url(assets/cheminTransport/fondtransport.svg) no-repeat center" hidden>
                 <img src="assets/cheminTransport/bulle-info-lg.svg" class="absolute inset-0 w-1/2 mt-5 mx-auto"
                      id="ic-bulle-info-transport" alt="Bulle info"></img>

--- a/velo-b/public/index.html
+++ b/velo-b/public/index.html
@@ -220,7 +220,7 @@
 
 
             <!--
-            <section data-slidr="infos-choix-voiture" hidden>
+            <section data-slidr="info-choix-voiture" hidden>
                 <header>
                     <div class="flex justify-center my-5">
                         <img src="assets/choix/indicationchoix.svg" id="indication-choix"

--- a/velo-b/public/index.html
+++ b/velo-b/public/index.html
@@ -155,12 +155,12 @@
                 </header>
 
                 <div class="flex flex-row justify-between items-center my-20">
-                    <img src="assets/choix/flecheG.svg" id="fleche-gauche-bycl" alt="Fleche Gauche"></img>
+                    <img src="assets/choix/flecheG.svg" id="fleche-gauche-bicl" alt="Fleche Gauche"></img>
                     <div class="transport-column">
                         <img src="assets/choix/bicloo.svg" class="illu-vehicule" id="bicloo" alt="bicloo"></img>
                         <p class="flex justify-center my-5 choisis_ton_moyen_de_transport">Bicloo</p>
                     </div>
-                    <img src="assets/choix/flecheD.svg" id="fleche-droite-bycl" alt="Fleche Droite"></img>
+                    <img src="assets/choix/flecheD.svg" id="fleche-droite-bicl" alt="Fleche Droite"></img>
                 </div>
 
                 <div class="flex items-end justify-center">

--- a/velo-b/public/js/carte.js
+++ b/velo-b/public/js/carte.js
@@ -27,7 +27,7 @@ registerSlide("page-carte", function () {
 
                 console.log(this.id); // selectionné
                 zoneChoisie = this.id;
-                goToSlide('choix-transport-2');
+                goToSlide('choix-transport-velo');
             });
     });
 });

--- a/velo-b/public/js/carte.js
+++ b/velo-b/public/js/carte.js
@@ -1,6 +1,10 @@
 const disabledZone = "centre";
 
+let lastId, lastEvent, lastFn, lastThis;
+
 registerSlide("page-carte", function () {
+    [lastId, lastEvent, lastFn, lastThis] = [];
+
     d3.xml("assets/carte.svg").then(data => {
         const carte = d3.select("#carte");
         // clear au cas où des cartes sont déjà présentes
@@ -31,8 +35,6 @@ registerSlide("page-carte", function () {
     });
 });
 
-let lastId, lastEvent, lastFn, lastThis;
-
 function debounce(id, event, fn) {
     if (this.id === disabledZone)
         return;
@@ -42,6 +44,5 @@ function debounce(id, event, fn) {
         fn.call(this);
     }
 
-    // On reset tout si on est sorti de la slide.
-    [lastId, lastEvent, lastFn, lastThis] = window.currentSlide === 'page-carte' ? [id, event, fn, this] : [];
+    [lastId, lastEvent, lastFn, lastThis] = [id, event, fn, this];
 }

--- a/velo-b/public/js/carte.js
+++ b/velo-b/public/js/carte.js
@@ -25,9 +25,8 @@ registerSlide("page-carte", function () {
                 if (this.id === disabledZone)
                     return;
 
-                console.log(this.id); // selectionné
-                zoneChoisie = this.id;
-                goToSlide('choix-transport-velo');
+                window.zoneChoisie = this.id;
+                goToNextSlide(this.id);
             });
     });
 });

--- a/velo-b/public/js/carte.js
+++ b/velo-b/public/js/carte.js
@@ -42,5 +42,6 @@ function debounce(id, event, fn) {
         fn.call(this);
     }
 
-    [lastId, lastEvent, lastFn, lastThis] = [id, event, fn, this];
+    // On reset tout si on est sorti de la slide.
+    [lastId, lastEvent, lastFn, lastThis] = window.currentSlide === 'page-carte' ? [id, event, fn, this] : [];
 }

--- a/velo-b/public/js/choix.js
+++ b/velo-b/public/js/choix.js
@@ -4,13 +4,8 @@
 registerSlide("choix-transport-bicloo", function () {
   
   /*==================== Fleches ===========================*/
-
-  const idFlecheD = '#fleche-droite-bycl';
-  const idFlecheG = '#fleche-gauche-bycl';
-  const nextD = 'choix-transport-transports';
-  const nextG = 'choix-transport-velo';
-  arrowbutton(idFlecheD, nextD);
-  arrowbutton(idFlecheG, nextG);
+  arrowbutton('#fleche-gauche-bicl', 'gauche');
+  arrowbutton('#fleche-droite-bicl', 'droite');
 
   //retour
   const idFlecheRetour = '#fleche-retour-bicl';
@@ -38,12 +33,9 @@ registerSlide("choix-transport-bicloo", function () {
 
 registerSlide("choix-transport-transports", function () {
 
-  const idFlecheD = '#fleche-droite-trans';
-  const idFlecheG = '#fleche-gauche-trans';
-  const nextD = 'choix-transport-voiture';
-  const nextG = 'choix-transport-bicloo';
-  arrowbutton(idFlecheD, nextD);
-  arrowbutton(idFlecheG, nextG);
+  /*==================== Fleches ===========================*/
+  arrowbutton('#fleche-gauche-trans', 'gauche');
+  arrowbutton('#fleche-droite-trans', 'droite');
 
   //retour
   const idFlecheRetour = '#fleche-retour-trans';
@@ -84,13 +76,8 @@ registerSlide("choix-transport-transports", function () {
 registerSlide("choix-transport-velo",function () {
 
   /*==================== Fleches ===========================*/
-
-  const idFlecheD = '#fleche-droite-velo';
-  const idFlecheG = '#fleche-gauche-velo';
-  const nextD = 'choix-transport-bicloo';
-  const nextG = 'choix-transport-voiture';
-  arrowbutton(idFlecheD, nextD);
-  arrowbutton(idFlecheG, nextG);
+  arrowbutton('#fleche-gauche-velo', 'gauche');
+  arrowbutton('#fleche-droite-velo', 'droite');
   
   //retour
   const idFlecheRetour = '#fleche-retour-velo';
@@ -120,12 +107,9 @@ registerSlide("choix-transport-voiture", function () {
   
    /*==================== Fleches ===========================*/
 
-   const idFlecheD = '#fleche-droite-voit';
-   const idFlecheG = '#fleche-gauche-voit';
-   const nextD = 'choix-transport-velo';
-   const nextG = 'choix-transport-transports';
-   arrowbutton(idFlecheD, nextD);
-   arrowbutton(idFlecheG, nextG);
+  /*==================== Fleches ===========================*/
+  arrowbutton('#fleche-gauche-voit', 'gauche');
+  arrowbutton('#fleche-droite-voit', 'droite');
 
    
   //retour
@@ -150,14 +134,13 @@ registerSlide("choix-transport-voiture", function () {
   infobutton();
 });
 
-// TODO: ajouter les arrows dans le graphe
-let arrowbutton = function (idButton, page) {
+let arrowbutton = function (idButton, choice) {
   d3.select(idButton).on('click', function () {
     overrideAnim({
       targets: idButton,
       scale: 1
     });
-    goToSlide(page);
+    goToNextSlide(choice);
   });
 
   d3.select(idButton).on('mouseover', function () {

--- a/velo-b/public/js/choix.js
+++ b/velo-b/public/js/choix.js
@@ -6,11 +6,7 @@ registerSlide("choix-transport-bicloo", function () {
   /*==================== Fleches ===========================*/
   arrowbutton('#fleche-gauche-bicl', 'gauche');
   arrowbutton('#fleche-droite-bicl', 'droite');
-
-  //retour
-  const idFlecheRetour = '#fleche-retour-bicl';
-  const retour = 'page-carte';
-  retourbutton(idFlecheRetour, retour);
+  retourbutton('#fleche-retour-bicl');
 
   /*====================Bouton du bas ===========================*/
   d3.select('#plus-info-bicloo').on('click', function () {
@@ -36,11 +32,7 @@ registerSlide("choix-transport-transports", function () {
   /*==================== Fleches ===========================*/
   arrowbutton('#fleche-gauche-trans', 'gauche');
   arrowbutton('#fleche-droite-trans', 'droite');
-
-  //retour
-  const idFlecheRetour = '#fleche-retour-trans';
-  const retour = 'page-carte';
-  retourbutton(idFlecheRetour, retour);
+  retourbutton('#fleche-retour-trans');
 
 
   /*====================Bouton du bas ===========================*/
@@ -78,11 +70,7 @@ registerSlide("choix-transport-velo",function () {
   /*==================== Fleches ===========================*/
   arrowbutton('#fleche-gauche-velo', 'gauche');
   arrowbutton('#fleche-droite-velo', 'droite');
-  
-  //retour
-  const idFlecheRetour = '#fleche-retour-velo';
-  const retour = 'page-carte';
-  retourbutton(idFlecheRetour, retour);
+  retourbutton('#fleche-retour-velo');
 
   /*====================Bouton du bas ===========================*/
 
@@ -110,12 +98,7 @@ registerSlide("choix-transport-voiture", function () {
   /*==================== Fleches ===========================*/
   arrowbutton('#fleche-gauche-voit', 'gauche');
   arrowbutton('#fleche-droite-voit', 'droite');
-
-   
-  //retour
-  const idFlecheRetour = '#fleche-retour-voit';
-  const retour = 'page-carte';
-  retourbutton(idFlecheRetour, retour);
+  retourbutton('#fleche-retour-voit');
  
    /*====================Bouton du bas ===========================*/
 
@@ -203,8 +186,7 @@ let retourbutton = function (idButton, page) {
       targets: idButton,
       scale: 1
     });
-    // TODO: ajouter retour dans graphe
-    goToSlide(page);
+    goToNextSlide('retour');
   });
 
   d3.select(idButton).on('mouseover', function () {

--- a/velo-b/public/js/choix.js
+++ b/velo-b/public/js/choix.js
@@ -1,14 +1,14 @@
 // SLIDE CHOIX BICLOO
 
 
-registerSlide("choix-transport-3", function () {
+registerSlide("choix-transport-bicloo", function () {
   
   /*==================== Fleches ===========================*/
 
   const idFlecheD = '#fleche-droite-bycl';
   const idFlecheG = '#fleche-gauche-bycl';
-  const nextD = 'choix-transport-4';
-  const nextG = 'choix-transport-2';
+  const nextD = 'choix-transport-transports';
+  const nextG = 'choix-transport-velo';
   arrowbutton(idFlecheD, nextD);
   arrowbutton(idFlecheG, nextG);
 
@@ -26,7 +26,7 @@ registerSlide("choix-transport-3", function () {
     goToSlide('info-choix-bicloo');
   });
 
-  const infoSelection = 'infos-selection-bicloo';
+  const infoSelection = 'question-bicloo-autres-transports';
   const idOkButton = '#ok-bicloo';
   okbutton(idOkButton,infoSelection);
   infobutton();
@@ -36,12 +36,12 @@ registerSlide("choix-transport-3", function () {
 // SLIDE CHOIX TRANSPORT EN COMMUN
 
 
-registerSlide("choix-transport-4", function () {
+registerSlide("choix-transport-transports", function () {
 
   const idFlecheD = '#fleche-droite-trans';
   const idFlecheG = '#fleche-gauche-trans';
-  const nextD = 'choix-transport-1';
-  const nextG = 'choix-transport-3';
+  const nextD = 'choix-transport-voiture';
+  const nextG = 'choix-transport-bicloo';
   arrowbutton(idFlecheD, nextD);
   arrowbutton(idFlecheG, nextG);
 
@@ -61,7 +61,7 @@ registerSlide("choix-transport-4", function () {
   });
 
 
-  const infoSelection = 'infos-selection-transport';
+  const infoSelection = 'question-transports-velo';
   const idOkButton = '#ok-transport';
   okbutton(idOkButton,infoSelection);
   infobutton();
@@ -81,14 +81,14 @@ registerSlide("choix-transport-4", function () {
 
 // SLIDE CHOIX VELO
 
-registerSlide("choix-transport-2",function () {
+registerSlide("choix-transport-velo",function () {
 
   /*==================== Fleches ===========================*/
 
   const idFlecheD = '#fleche-droite-velo';
   const idFlecheG = '#fleche-gauche-velo';
-  const nextD = 'choix-transport-3';
-  const nextG = 'choix-transport-1';
+  const nextD = 'choix-transport-bicloo';
+  const nextG = 'choix-transport-voiture';
   arrowbutton(idFlecheD, nextD);
   arrowbutton(idFlecheG, nextG);
   
@@ -107,7 +107,7 @@ registerSlide("choix-transport-2",function () {
     goToSlide('info-choix-velo');
   });
 
-  const infoSelection = 'infos-selection-velo';
+  const infoSelection = 'question-velo-autres-transports';
   const idOkButton = '#ok-velo';
   okbutton(idOkButton,infoSelection);
   infobutton();
@@ -116,14 +116,14 @@ registerSlide("choix-transport-2",function () {
 
 // SLIDE CHOIX VOITURE
 
-registerSlide("choix-transport-1", function () {
+registerSlide("choix-transport-voiture", function () {
   
    /*==================== Fleches ===========================*/
 
    const idFlecheD = '#fleche-droite-voit';
    const idFlecheG = '#fleche-gauche-voit';
-   const nextD = 'choix-transport-2';
-   const nextG = 'choix-transport-4';
+   const nextD = 'choix-transport-velo';
+   const nextG = 'choix-transport-transports';
    arrowbutton(idFlecheD, nextD);
    arrowbutton(idFlecheG, nextG);
 
@@ -144,7 +144,7 @@ registerSlide("choix-transport-1", function () {
     goToSlide('info-choix-voiture');
   });
 
-  const infoSelection = 'infos-selection-voiture';
+  const infoSelection = 'question-voiture-velo';
   const idOkButton = '#ok-voiture';
   okbutton(idOkButton,infoSelection);
   infobutton();

--- a/velo-b/public/js/choix.js
+++ b/velo-b/public/js/choix.js
@@ -23,7 +23,7 @@ registerSlide("choix-transport-bicloo", function () {
       targets: '#plus-info-bicloo',
       scale: 0
     });
-    goToSlide('info-choix-bicloo');
+    goToNextSlide('info');
   });
 
   const infoSelection = 'question-bicloo-autres-transports';
@@ -57,7 +57,7 @@ registerSlide("choix-transport-transports", function () {
       targets: '#plus-info-transports',
       scale: 0
     });
-    goToSlide('info-choix-transports');
+    goToNextSlide('info');
   });
 
 
@@ -104,7 +104,7 @@ registerSlide("choix-transport-velo",function () {
       targets: ['#plus-info-velo'],
       scale: 0
     });
-    goToSlide('info-choix-velo');
+    goToNextSlide('info');
   });
 
   const infoSelection = 'question-velo-autres-transports';
@@ -141,7 +141,7 @@ registerSlide("choix-transport-voiture", function () {
       targets: '#plus-info-voiture',
       scale: 0
     });
-    goToSlide('info-choix-voiture');
+     goToNextSlide('info');
   });
 
   const infoSelection = 'question-voiture-velo';
@@ -150,7 +150,7 @@ registerSlide("choix-transport-voiture", function () {
   infobutton();
 });
 
-
+// TODO: ajouter les arrows dans le graphe
 let arrowbutton = function (idButton, page) {
   d3.select(idButton).on('click', function () {
     overrideAnim({
@@ -184,9 +184,8 @@ let okbutton = function (idbutton,page) {
       targets: idbutton,
       scale: 0
     });
-    goToSlide(page);
+    goToNextSlide("ok");
   });
-
 }
 
 let infobutton = function (page) {
@@ -195,7 +194,7 @@ let infobutton = function (page) {
       targets: '#plus-info',
       scale: 0
     });
-    goToSlide('page-finale');
+    goToNextSlide('info');
   });
 }
 
@@ -214,14 +213,14 @@ function changeImage(element) {
 }
 
 
-
 let retourbutton = function (idButton, page) {
-  
+
   d3.select(idButton).on('click', function () {
     overrideAnim({
       targets: idButton,
       scale: 1
     });
+    // TODO: ajouter retour dans graphe
     goToSlide(page);
   });
 

--- a/velo-b/public/js/globals.js
+++ b/velo-b/public/js/globals.js
@@ -1,9 +1,19 @@
-window.slides = {};
-
 let zoneChoisie = null, vehiculeChoisi = null;
 
+window.slideGraph = {};
+
+// Chargement du graphe des slides.
+d3.json('data/slide-graph.json').then(slides => {
+    for (const name in slides) {
+        window.slideGraph[name] = {
+            ...window.slideGraph[name],
+            ...slides[name]
+        };
+    }
+});
+
 function registerSlide(name, init) {
-    window.slides[name] = init;
+    window.slideGraph[name] = { ...window.slideGraph[name], init };
 }
 
 function goToSlide(name) {
@@ -12,7 +22,7 @@ function goToSlide(name) {
     mySlidr.slide(name);
 
     try {
-        window.slides[name]();
+        window.slideGraph[name].init();
     } catch {
         alert(`La page "${name}" n'est pas registered avec registerSlide() !`);
     }
@@ -43,24 +53,28 @@ const initButtons = function () {
         });
 };
 
-const fetchJsonData = function(addr, callback) {
+const fetchJsonData = function (addr, callback) {
     fetch(addr)
-    .then(function(response) {
-        if (response.ok) {
-            response.json()
-            .then(function(data) {
-                callback(data);
-            })
-            .catch(e => {console.error(e);});
-        } else {
-            console.error(response+" is not valid");
-        }
-    })
-    .catch(e => {console.error(e);});
+        .then(function (response) {
+            if (response.ok) {
+                response.json()
+                    .then(function (data) {
+                        callback(data);
+                    })
+                    .catch(e => {
+                        console.error(e);
+                    });
+            } else {
+                console.error(response + " is not valid");
+            }
+        })
+        .catch(e => {
+            console.error(e);
+        });
 };
 
 registerSlide("slides", () => {
-    const slideNames = Object.keys(window.slides);
+    const slideNames = Object.keys(window.slideGraph);
     const list = document.getElementById("slide-list");
 
     list.innerHTML = '';

--- a/velo-b/public/js/globals.js
+++ b/velo-b/public/js/globals.js
@@ -1,6 +1,8 @@
-let zoneChoisie = null, vehiculeChoisi = null;
+window.zoneChoisie = null;
+window.vehiculeChoisi = null;
 
 window.slideGraph = {};
+window.currentSlide = null;
 
 // Chargement du graphe des slides.
 d3.json('data/slide-graph.json').then(slides => {
@@ -16,15 +18,28 @@ function registerSlide(name, init) {
     window.slideGraph[name] = { ...window.slideGraph[name], init };
 }
 
+function goToNextSlide(choice) {
+    const current = window.slideGraph[window.currentSlide];
+    if (!current) alert(`La slide ${window.currentSlide} (actuelle) n'existe pas !`);
+
+    const next = current.next[choice];
+    if (!current) alert(`Le choix ${choice} n'est pas disponible pour la slide ${window.currentSlide}`);
+
+    goToSlide(next);
+}
+
 function goToSlide(name) {
+    if (!name) alert(`Le choix ${name} n'est pas disponible pour la slide ${window.currentSlide}`);
+
     name = name.match(/#?(.*)/)[1]; // Remove hashtag.
 
     mySlidr.slide(name);
+    window.currentSlide = name;
 
     try {
         window.slideGraph[name].init();
     } catch {
-        alert(`La page "${name}" n'est pas registered avec registerSlide() !`);
+        alert(`La slide "${name}" n'est pas registered avec registerSlide() !`);
     }
 }
 

--- a/velo-b/public/js/infosChoix.js
+++ b/velo-b/public/js/infosChoix.js
@@ -11,7 +11,7 @@ registerSlide("info-choix-velo", function () {
             targets: '#close-btn-velo',
             scale: 0
         });
-        goToSlide('choix-transport-velo');
+        goToNextSlide('ok');
     });
 
     d3.select('#close-btn-velo').on('mouseover', function () {
@@ -47,7 +47,7 @@ registerSlide("info-choix-voiture", function () {
             targets: '#close-btn-voiture',
             scale: 0
         });
-        goToSlide('choix-transport-voiture');
+        goToNextSlide('ok');
     });
 
     d3.select('#close-btn-voiture').on('mouseover', function () {
@@ -81,7 +81,7 @@ registerSlide("info-choix-bicloo", function () {
             targets: '#close-btn-bicloo',
             scale: 0
         });
-        goToSlide('choix-transport-bicloo');
+        goToNextSlide('ok');
     });
 
     d3.select('#close-btn-bicloo').on('mouseover', function () {
@@ -123,7 +123,7 @@ registerSlide("info-choix-transports", function () {
             targets: '#close-btn-transports',
             scale: 0
         });
-        goToSlide('choix-transport-transports');
+        goToNextSlide('ok');
     });
 
     d3.select('#close-btn-transports').on('mouseover', function () {

--- a/velo-b/public/js/infosChoix.js
+++ b/velo-b/public/js/infosChoix.js
@@ -11,7 +11,7 @@ registerSlide("info-choix-velo", function () {
             targets: '#close-btn-velo',
             scale: 0
         });
-        goToSlide('choix-transport-2');
+        goToSlide('choix-transport-velo');
     });
 
     d3.select('#close-btn-velo').on('mouseover', function () {
@@ -47,7 +47,7 @@ registerSlide("info-choix-voiture", function () {
             targets: '#close-btn-voiture',
             scale: 0
         });
-        goToSlide('choix-transport-1');
+        goToSlide('choix-transport-voiture');
     });
 
     d3.select('#close-btn-voiture').on('mouseover', function () {
@@ -81,7 +81,7 @@ registerSlide("info-choix-bicloo", function () {
             targets: '#close-btn-bicloo',
             scale: 0
         });
-        goToSlide('choix-transport-3');
+        goToSlide('choix-transport-bicloo');
     });
 
     d3.select('#close-btn-bicloo').on('mouseover', function () {
@@ -123,7 +123,7 @@ registerSlide("info-choix-transports", function () {
             targets: '#close-btn-transports',
             scale: 0
         });
-        goToSlide('choix-transport-4');
+        goToSlide('choix-transport-transports');
     });
 
     d3.select('#close-btn-transports').on('mouseover', function () {

--- a/velo-b/public/js/selectionChoix.js
+++ b/velo-b/public/js/selectionChoix.js
@@ -1,20 +1,20 @@
-registerSlide("infos-selection-voiture", function () {
+registerSlide("question-voiture-velo", function () {
     const idYesBut = '#ic-oui-voit';
     const idNoBut = '#ic-non-voit';
     button(idYesBut, 'info-choix-velo'); // TODO: changer ça
 });
 
-registerSlide("infos-selection-velo", function () {
+registerSlide("question-velo-autres-transports", function () {
     const idYesBut = '#ic-oui-velo';
     const idNoBut = '#ic-non-velo';
 });
 
-registerSlide("infos-selection-bicloo", function () {
+registerSlide("question-bicloo-autres-transports", function () {
     const idYesBut = '#ic-oui-bicloo';
     const idNoBut = '#ic-non-bicloo';
 });
 
-registerSlide("infos-selection-transport", function () {
+registerSlide("question-transports-velo", function () {
 
 });
 

--- a/velo-b/public/js/selectionChoix.js
+++ b/velo-b/public/js/selectionChoix.js
@@ -1,29 +1,29 @@
 registerSlide("question-voiture-velo", function () {
-    const idYesBut = '#ic-oui-voit';
-    const idNoBut = '#ic-non-voit';
-    button(idYesBut, 'info-choix-velo'); // TODO: changer ça
+    button( '#ic-oui-voit', 'oui');
+    button( '#ic-non-voit', 'non');
 });
 
 registerSlide("question-velo-autres-transports", function () {
-    const idYesBut = '#ic-oui-velo';
-    const idNoBut = '#ic-non-velo';
+    button( '#ic-oui-velo', 'oui');
+    button( '#ic-non-velo', 'non');
 });
 
 registerSlide("question-bicloo-autres-transports", function () {
-    const idYesBut = '#ic-oui-bicloo';
-    const idNoBut = '#ic-non-bicloo';
+    button( '#ic-oui-bicloo', 'oui');
+    button( '#ic-non-bicloo', 'non');
 });
 
 registerSlide("question-transports-velo", function () {
-
+    button( '#ic-oui-transport', 'oui');
+    button( '#ic-non-transport', 'non');
 });
 
-let button = function (idbutton, page) {
+let button = function (idbutton, choice) {
     d3.select(idbutton).on('click', function () {
         overrideAnim({
             targets: idbutton,
             scale: 0
         });
-        goToSlide(page);
+        goToNextSlide(choice);
     });
 };

--- a/velo-b/public/js/slide1.js
+++ b/velo-b/public/js/slide1.js
@@ -5,7 +5,7 @@ registerSlide("page-accueil", function () {
             targets: '#startButton',
             scale: 0
         });
-        goToSlide('page-carte');
+        goToNextSlide('ok');
     });
 
     d3.select('#startButton').on('mouseover', function () {

--- a/velo-b/public/js/splashscreen.js
+++ b/velo-b/public/js/splashscreen.js
@@ -9,6 +9,9 @@ registerSlide("splash-screen", function () {
     anim.setSpeed(2.5);
 
     anim.addEventListener("data_ready", () => {
-        setTimeout(() => goToNextSlide('timeout'), 2000);
+        setTimeout(() => {
+            anim.destroy();
+            goToNextSlide('timeout');
+        }, 2000);
     });
 });

--- a/velo-b/public/js/splashscreen.js
+++ b/velo-b/public/js/splashscreen.js
@@ -1,5 +1,3 @@
-// TODO: ajouter splash screen au graphe, choice = timeout
-
 registerSlide("splash-screen", function () {
     const anim = bodymovin.loadAnimation({
         container: document.getElementById('logo-anim'),
@@ -11,8 +9,6 @@ registerSlide("splash-screen", function () {
     anim.setSpeed(2.5);
 
     anim.addEventListener("data_ready", () => {
-        setTimeout(() => {
-            goToSlide('page-accueil');
-        }, 2000);
+        setTimeout(() => goToNextSlide('timeout'), 2000);
     });
 });

--- a/velo-b/public/js/splashscreen.js
+++ b/velo-b/public/js/splashscreen.js
@@ -1,3 +1,5 @@
+// TODO: ajouter splash screen au graphe, choice = timeout
+
 registerSlide("splash-screen", function () {
     const anim = bodymovin.loadAnimation({
         container: document.getElementById('logo-anim'),


### PR DESCRIPTION
- Plus jamais de choix manuel de vers quelle slide on transitionne : utiliser le graphe.
  - Le graphe est censé correspondre au Miro et au Figma, donc il faut s'y tenir, **aux noms de slides surtout**
  - Si vous voulez modifier des transitions dans le graphe temporairement, vous pouvez faire un backup dans `realNext` ([comme ici](https://github.com/Drarig29/Hyblab2021/pull/21/files#diff-277d032e29d86cd9ca6e223a6caba00083dd72e5736c3e66348cd529f68fd756R19-R24)), et remplacer ce que vous voulez dans `next`.


- Les slides `choix-transport-<nombre>` sont renommées en `choix-transport-<vrai_nom>`
- @fouillardT j'ai renommé tes sections `infos-selection-*` en des noms qui donnent le contexte précédent **et aussi actuel**

------

**TLDR :**

Ne plus utiliser `goToSlide(nom)` mais `goToNextSlide(choice)` où `choice` est une key de `next` dans le graphe JSON.
  - Exemple : `goToNextSlide('ok')`. La fonction sait toute seule sur quelle slide on est en ce moment.


Le reste c'est de la refactorisation en rapport avec l'utilisation du graphe et des bugfix.